### PR TITLE
fix spelling typos

### DIFF
--- a/lib/Locale/XGettext.pod
+++ b/lib/Locale/XGettext.pod
@@ -530,7 +530,7 @@ consisting of four items:
 =item *
 
 The option specification for Getopt::Long(3pm), for example
-"f|filename=s" for an option expexting a mandatory
+"f|filename=s" for an option expecting a mandatory
 string argument.
 
 =item *
@@ -624,7 +624,7 @@ option "-D, --directory".
 
 =item B<defaultKeywords>
 
-Returns a reference to an emtpy array.
+Returns a reference to an empty array.
 
 Subclasses may return a reference to an array with default keyword
 definitions for the specific language.  The default keywords 
@@ -643,7 +643,7 @@ for more information about the meaning of these strings.
 
 =item B<defaultFlags>
 
-Returns a reference to an emtpy array.
+Returns a reference to an empty array.
 
 Subclasses may return a reference to an array with default flag
 specifications for the specific language.  An example may look

--- a/lib/Locale/XGettext/Util/Flag.pod
+++ b/lib/Locale/XGettext/Util/Flag.pod
@@ -42,7 +42,7 @@ An integer B<N> greater than 0 for the argument number.
 The name of the flag to be applied, for example "perl-brace-format"
 or "no-perl-brace-format".  A possible prefix of "no-" or "pass-"
 is stripped off and interpreted accordingly but only if "pass" or
-"no" were not explicitely specified.
+"no" were not explicitly specified.
 
 =item B<no>
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Locale-XGettext.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/liblocale-xgettext-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
