### PR TITLE
add missing TestLib package declaration

### DIFF
--- a/t/TestLib.pm
+++ b/t/TestLib.pm
@@ -18,6 +18,8 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
 # USA.
 
+package TestLib;
+
 use strict;
 
 use vars qw(@ISA @EXPORT_OK);


### PR DESCRIPTION
The TestLib module was missing a package declaration. Various test scripts were loading the module and trying to import subs from it. Since TestLib had no subs or any import method defined, those attempted imports would be silently ignored. But because TestLib didn't declate a package at all, its subs would end up in the current package of where it was loaded, and they would be available anyway. This was not the intended behavior, and future perl versions are intending to make it an error to pass arguments to an undefined import method.

Fixes #8